### PR TITLE
correct number of column_bit in mt48lc4m32b2_6

### DIFF
--- a/src/devices/mt48lc4m32b2.rs
+++ b/src/devices/mt48lc4m32b2.rs
@@ -46,7 +46,7 @@ pub mod mt48lc4m32b2_6 {
 
         /// SDRAM controller configuration
         const CONFIG: SdramConfiguration = SdramConfiguration {
-            column_bits: 9,
+            column_bits: 8,
             row_bits: 12,
             memory_data_width: 32, // 32-bit
             internal_banks: 4,     // 4 internal banks

--- a/src/devices/mt48lc4m32b2.rs
+++ b/src/devices/mt48lc4m32b2.rs
@@ -1,8 +1,6 @@
 /// Micron MT48LC4M32B2 SDRAM
 #[allow(unused)]
 
-/// UNTESTED!
-
 /// Speed Grade 6
 pub mod mt48lc4m32b2_6 {
     use crate::sdram::{SdramChip, SdramConfiguration, SdramTiming};


### PR DESCRIPTION
Hi,
I tried using this crate with a mt48lc4m32b2_6 on the stm32f469I-discovery board.
when using a slice in the sdram, some values are duplicated. 
for instance with a slice [u32; 2000] at address 0xc0177000. 
The value of first element at address 0xc0177000 of the slice is always equals to the value of the element at address 0xc177400.

Changing the column_bit value from 9 to 8 correct this.