### PR TITLE
Add support for Parallel NAND Flash

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,1 +1,4 @@
-status = ["ci"]
+status = [
+    "build-dev (1.43.0)",
+    "build-dev (stable)",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,4 @@ jobs:
 
       - name: Build
         run: |
-          cargo test --verbose --features=sdram
+          cargo test --verbose --features=sdram,nand

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 exclude = [".gitignore"]
 
 [package.metadata.docs.rs]
-features = ["sdram"]
+features = ["sdram", "nand"]
 
 [dependencies.log]
 version = "^0.4.8"
@@ -32,4 +32,5 @@ paste = "1.0"
 [features]
 trace-register-values = []
 sdram = []
-default = ["sdram"]
+nand = []
+default = ["sdram", "nand"]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ directly.
 
 #### Initialising
 
-Once you have an `Sdram` type, you can:
+Once you have an
+[`Sdram`](https://docs.rs/stm32-fmc/latest/stm32_fmc/struct.Sdram.html)
+instance, you can:
 
 * Initialise it by calling
   [`init`](https://docs.rs/stm32-fmc/latest/stm32_fmc/struct.Sdram.html#method.init). This
@@ -118,7 +120,9 @@ directly.
 
 #### Initialising
 
-Once you have an `Nand` type you should initialise it by calling
+Once you have an
+[`Nand`](https://docs.rs/stm32-fmc/latest/stm32_fmc/struct.Nand.html) instance
+you should initialise it by calling
 [`init`](https://docs.rs/stm32-fmc/latest/stm32_fmc/struct.Nand.html#method.init). This
 returns a
 [`NandDevice`](https://docs.rs/stm32-fmc/latest/stm32_fmc/nand_device/struct.NandDevice.html)

--- a/README.md
+++ b/README.md
@@ -80,20 +80,67 @@ let ram = unsafe {
 };
 ```
 
+### NAND Flash
+
+The FMC peripheral supports once external parallel NAND flash device.
+
+External memories are defined by
+[`NandChip`](https://docs.rs/stm32-fmc/latest/stm32_fmc/trait.NandChip.html)
+implementations. There are examples in the [`devices`](src/devices/) folder, or
+you can make your own.
+
+To pass pins to a constructor, create a tuple with the following ordering:
+
+```rust
+let pins = (
+    // A17/ALE
+    // A16/CLE
+    pa0, ...
+    // D0-D7
+    // NCE/#CE
+    // NOE/#RE
+    // NWE/#WE
+    // NWAIT/R/#B
+);
+```
+
+#### Constructing
+
+If you are using a HAL, see the HAL documentation.
+
+Otherwise you can implement
+[`FmcPeripheral`](https://docs.rs/stm32-fmc/latest/stm32_fmc/trait.FmcPeripheral.html)
+yourself then use
+[`Nand::new`](https://docs.rs/stm32-fmc/latest/stm32_fmc/struct.Nand.html#method.new)
+/
+[`Nand::new_unchecked`](https://docs.rs/stm32-fmc/latest/stm32_fmc/struct.Nand.html#method.new_unchecked)
+directly.
+
+#### Initialising
+
+Once you have an `Nand` type you should initialise it by calling
+[`init`](https://docs.rs/stm32-fmc/latest/stm32_fmc/struct.Nand.html#method.init). This
+returns a
+[`NandDevice`](https://docs.rs/stm32-fmc/latest/stm32_fmc/nand_device/struct.NandDevice.html)
+instance.
+
+```rust
+let mut nand_device = nand.init(&mut delay);
+
+// Read device identifier
+let id = nand_device.read_id();
+```
+
 ### NOR Flash/PSRAM
 
 TODO
 
-### NAND Flash
-
-TODO
-
 ### Troubleshooting
-The library automatically does some trace-level logging either via `log` or via `defmt`. 
+The library automatically does some trace-level logging either via `log` or via `defmt`.
 To enable such logging, enable either the `log` or `defmt` feature in your `Cargo.toml`.
 
-For debugging the SDRAM register contents, the library provides additional feature `trace-register-values`, which when enabled causes the init function to log the register contents to the trace level. 
-This is useful for example when you want to compare the register values between `stm32-fmc` and CubeMX code. 
+For debugging the SDRAM register contents, the library provides additional feature `trace-register-values`, which when enabled causes the init function to log the register contents to the trace level.
+This is useful for example when you want to compare the register values between `stm32-fmc` and CubeMX code.
 Note that one of the logging features (`log`/`defmt`) must be enabled for this to work.
 
 ### Implementing a new device

--- a/src/devices/as4c4m16sa.rs
+++ b/src/devices/as4c4m16sa.rs
@@ -1,5 +1,5 @@
 /// Alliance Memory AS4C4M16SA SDRAM
-/// https://www.alliancememory.com/wp-content/uploads/pdf/dram/Alliance_Memory_64M-AS4C4M16SA-CI_v5.0_October_2018.pdf
+/// <https://www.alliancememory.com/wp-content/uploads/pdf/dram/Alliance_Memory_64M-AS4C4M16SA-CI_v5.0_October_2018.pdf>
 #[allow(unused)]
 
 pub mod as4c4m16sa_6 {

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -24,3 +24,8 @@ pub use is42s32800g::*;
 mod mt48lc4m32b2;
 #[cfg(feature = "sdram")]
 pub use mt48lc4m32b2::*;
+
+#[cfg(feature = "nand")]
+mod s34ml08g3;
+#[cfg(feature = "nand")]
+pub use s34ml08g3::*;

--- a/src/devices/s34ml08g3.rs
+++ b/src/devices/s34ml08g3.rs
@@ -1,0 +1,34 @@
+/// SkyHigh S34ML08G3 SLC NAND Flash
+#[allow(unused)]
+
+/// SkyHigh S34ML08G3 SLC NAND Flash with 4kB pages
+pub mod s34ml08g3_4kb {
+    use crate::nand::{NandChip, NandConfiguration, NandTiming};
+
+    /// S32ML08G3
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    pub struct S34ml08g3 {}
+
+    impl NandChip for S34ml08g3 {
+        /// Timing Parameters
+        const TIMING: NandTiming = NandTiming {
+            nce_setup_time: 15,       // tCS = 15ns min
+            data_setup_time: 7,       // tDS = 7ns min
+            ale_hold_time: 5,         // tALH = 5ns min
+            cle_hold_time: 5,         // tCLH = 5ns min
+            ale_to_nre_delay: 10,     // tAR = 10ns min
+            cle_to_nre_delay: 10,     // tCLR = 10ns min
+            nre_pulse_width_ns: 10,   // tRP = 10ns min
+            nwe_pulse_width_ns: 10,   // tWP = 10ns min
+            read_cycle_time_ns: 20,   // tRC = 20ns min
+            write_cycle_time_ns: 20,  // tWC = 20ns min
+            nwe_high_to_busy_ns: 100, // tWB = 100ns max
+        };
+
+        /// Nand controller configuration
+        const CONFIG: NandConfiguration = NandConfiguration {
+            data_width: 8,   // 8-bit
+            column_bits: 12, // 4096 byte pages
+        };
+    }
+}

--- a/src/fmc.rs
+++ b/src/fmc.rs
@@ -188,6 +188,23 @@ impl_32bit_sdram! {
     SdramBank2: [SDCKE1, SDNE1, 4, PBA1: BA1; AddressPins13 [PA11: A11, PA12: A12]]
 }
 
+// ---- NAND ----
+
+#[cfg(feature = "nand")]
+use crate::nand::PinsNand;
+
+#[cfg(feature = "nand")]
+#[rustfmt::skip]
+/// 8-bit NAND
+impl<ALE, CLE, PD0, PD1, PD2, PD3, PD4, PD5, PD6, PD7, PNCE, PNOE, PNWE, PNWAIT>
+    PinsNand
+    for (ALE, CLE, PD0, PD1, PD2, PD3, PD4, PD5, PD6, PD7, PNCE, PNOE, PNWE, PNWAIT)
+where ALE: A17, CLE: A16,
+      PD0: D0, PD1: D1, PD2: D2, PD3: D3, PD4: D4, PD5: D5, PD6: D6, PD7: D7,
+      PNCE: NCE, PNOE: NOE, PNWE: NWE, PNWAIT: NWAIT {
+    const N_DATA: usize = 8;
+}
+
 /// Marks a type as an A0 pin
 pub trait A0 {}
 /// Marks a type as an A1 pin
@@ -352,8 +369,6 @@ pub trait NBL1 {}
 pub trait NBL2 {}
 /// Marks a type as a NBL3 pin
 pub trait NBL3 {}
-/// Marks a type as a NCE pin
-pub trait NCE {}
 /// Marks a type as a NE1 pin
 pub trait NE1 {}
 /// Marks a type as a NE2 pin
@@ -364,6 +379,8 @@ pub trait NE3 {}
 pub trait NE4 {}
 /// Marks a type as a NL pin
 pub trait NL {}
+/// Marks a type as a NCE pin
+pub trait NCE {}
 /// Marks a type as a NOE pin
 pub trait NOE {}
 /// Marks a type as a NWAIT pin

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!
 //! ## Wrap constructor methods
 //!
-//! Each memory controller type ([`Sdram`](Sdram), `Nand` (todo), ..) provides both
+//! Each memory controller type ([`Sdram`](Sdram), [`Nand`](Nand), ..) provides both
 //! `new` and `new_unchecked` methods.
 //!
 //! For the convenience of users, you may want to wrap these with your `new` method,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,13 @@ pub use sdram::{
     SdramTargetBank, SdramTiming,
 };
 
+#[cfg(feature = "nand")]
+mod nand;
+#[cfg(feature = "nand")]
+pub use nand::device as nand_device;
+#[cfg(feature = "nand")]
+pub use nand::{Nand, NandChip, NandConfiguration, NandTiming, PinsNand};
+
 /// Memory device definitions
 pub mod devices;
 

--- a/src/nand.rs
+++ b/src/nand.rs
@@ -1,0 +1,263 @@
+//! HAL for FMC peripheral used to access NAND Flash
+//!
+
+use core::cmp;
+use core::marker::PhantomData;
+
+use embedded_hal::blocking::delay::DelayUs;
+
+use crate::fmc::{FmcBank, FmcRegisters};
+use crate::FmcPeripheral;
+
+use crate::ral::{fmc, modify_reg};
+
+pub mod device;
+
+/// FMC NAND Physical Interface Configuration
+///
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NandConfiguration {
+    /// Data path width in bits
+    pub data_width: u8,
+    /// Number of address bits used for the column address
+    pub column_bits: u8,
+}
+
+/// FMC NAND Timing parameters
+///
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct NandTiming {
+    /// nCE setup time tCS
+    pub nce_setup_time: i32,
+    /// Data setup time tDS
+    pub data_setup_time: i32,
+    /// ALE hold time
+    pub ale_hold_time: i32,
+    /// CLE hold time
+    pub cle_hold_time: i32,
+    /// ALE to nRE delay
+    pub ale_to_nre_delay: i32,
+    /// CLE to nRE delay
+    pub cle_to_nre_delay: i32,
+    /// nRE pulse width tRP
+    pub nre_pulse_width_ns: i32,
+    /// nWE pulse width tWP
+    pub nwe_pulse_width_ns: i32,
+    /// Read cycle time tRC
+    pub read_cycle_time_ns: i32,
+    /// Write cycle time tWC
+    pub write_cycle_time_ns: i32,
+    /// nWE high to busy tWB
+    pub nwe_high_to_busy_ns: i32,
+}
+
+/// Respresents a model of NAND chip
+pub trait NandChip {
+    /// NAND controller configuration
+    const CONFIG: NandConfiguration;
+    /// Timing parameters
+    const TIMING: NandTiming;
+}
+
+/// FMC Peripheral specialized as a NAND Controller. Not yet initialized.
+#[allow(missing_debug_implementations)]
+pub struct Nand<FMC, IC> {
+    /// Parameters for the NAND IC
+    _chip: PhantomData<IC>,
+    /// FMC peripheral
+    fmc: FMC,
+    /// Register access
+    regs: FmcRegisters,
+}
+
+/// Set of pins for a NAND
+pub trait PinsNand {
+    /// Number of data bus pins
+    const N_DATA: usize;
+}
+
+impl<IC: NandChip, FMC: FmcPeripheral> Nand<FMC, IC> {
+    /// New NAND instance
+    ///
+    /// `_pins` must be a set of pins connecting to an NAND on the FMC
+    /// controller
+    ///
+    /// # Panics
+    ///
+    /// * Panics if there is a mismatch between the data lines in `PINS` and the
+    /// NAND device
+    pub fn new<PINS>(fmc: FMC, _pins: PINS, _chip: IC) -> Self
+    where
+        PINS: PinsNand,
+    {
+        assert!(
+            PINS::N_DATA == IC::CONFIG.data_width as usize,
+            "NAND Data Bus Width mismatch between IC and controller"
+        );
+
+        Nand {
+            _chip: PhantomData,
+            fmc,
+            regs: FmcRegisters::new::<FMC>(),
+        }
+    }
+
+    /// New NAND instance
+    ///
+    /// # Safety
+    ///
+    /// This method does not ensure that IO pins are configured
+    /// correctly. Misconfiguration may result in a bus lockup or stall when
+    /// attempting to initialise the NAND device.
+    ///
+    /// The pins are not checked against the requirements for the NAND
+    /// chip. Using this method it is possible to initialise a NAND device
+    /// without sufficient pins to access the whole memory
+    ///
+    pub unsafe fn new_unchecked(fmc: FMC, _chip: IC) -> Self {
+        Nand {
+            _chip: PhantomData,
+            fmc,
+            regs: FmcRegisters::new::<FMC>(),
+        }
+    }
+
+    /// Initialise NAND instance. Delay is used to wait
+    ///
+    /// Returns a [`NandDevice`] instance
+    ///
+    /// # Panics
+    ///
+    /// * Panics if any setting in `IC::CONFIG` cannot be achieved
+    pub fn init<D>(&mut self, delay: &mut D) -> device::NandDevice
+    where
+        D: DelayUs<u8>,
+    {
+        // calculate clock period, round down
+        let fmc_source_ck_hz = self.fmc.source_clock_hz();
+        let ker_clk_period_ns = 1_000_000_000u32 / fmc_source_ck_hz;
+
+        // enable memory controller AHB register access
+        self.fmc.enable();
+
+        // device features and timing
+        self.set_features_timings(IC::CONFIG, IC::TIMING, ker_clk_period_ns);
+
+        // enable memory controller
+        self.fmc.memory_controller_enable();
+        delay.delay_us(1u8);
+
+        // NOTE(unsafe): FMC controller has been initialized and enabled for
+        // this bank
+        unsafe {
+            // Create device. NAND Flash is always on Bank 3
+            let ptr = FmcBank::Bank3.ptr() as *mut u8;
+            device::NandDevice::init(ptr, IC::CONFIG.column_bits as usize)
+        }
+    }
+
+    /// Program memory device features and timings
+    ///
+    /// Timing calculations from AN4761 Section 4.2
+    #[allow(non_snake_case)]
+    fn set_features_timings(
+        &mut self,
+        config: NandConfiguration,
+        timing: NandTiming,
+        period_ns: u32,
+    ) {
+        let period_ns = period_ns as i32;
+        let n_clock_periods = |time_ns: i32| {
+            (time_ns + period_ns - 1) / period_ns // round up
+        };
+        let t_CS = timing.nce_setup_time;
+        let t_DS = timing.data_setup_time;
+        let t_ALH = timing.ale_hold_time;
+        let t_CLH = timing.cle_hold_time;
+        let t_AR = timing.ale_to_nre_delay;
+        let t_CLR = timing.cle_to_nre_delay;
+        let t_RP = timing.nre_pulse_width_ns;
+        let t_WP = timing.nwe_pulse_width_ns;
+        let t_RC = timing.read_cycle_time_ns;
+        let t_WC = timing.write_cycle_time_ns;
+        let t_WB = timing.nwe_high_to_busy_ns;
+
+        // setup time before RE/WE assertion
+        let setup_time = cmp::max(t_CS, cmp::max(t_AR, t_CLR));
+        let set = cmp::max(n_clock_periods(setup_time - t_WP), 1) - 1;
+        assert!(set < 255, "FMC ker clock too fast"); // 255 = reserved
+
+        // RE/WE assertion time (minimum = 1)
+        let wait = cmp::max(n_clock_periods(cmp::max(t_RP, t_WP)), 2) - 1;
+        assert!(wait < 255, "FMC ker clock too fast"); // 255 = reserved
+
+        // hold time after RE/WE deassertion (minimum = 1)
+        let mut hold = cmp::max(n_clock_periods(cmp::max(t_ALH, t_CLH)), 1);
+        // satisfy total cycle time
+        let cycle_time = n_clock_periods(cmp::max(t_RC, t_WC));
+        while wait + 1 + hold + set + 1 < cycle_time {
+            hold += 1;
+        }
+        assert!(hold < 255, "FMC ker clock too fast"); // 255 = reserved
+
+        // hold time to meet t_WB timing
+        let atthold = cmp::max(n_clock_periods(t_WB), 2) - 1;
+        let atthold = cmp::max(atthold, hold);
+        assert!(atthold < 255, "FMC ker clock too fast"); // 255 = reserved
+
+        // CS assertion to data setup
+        let hiz = cmp::max(n_clock_periods(t_CS + t_WP - t_DS), 0);
+        assert!(hiz < 255, "FMC ker clock too fast"); // 255 = reserved
+
+        // ALE low to RE assert
+        let ale_to_nre = n_clock_periods(t_AR);
+        let tar = cmp::max(ale_to_nre - set - 2, 0);
+        assert!(tar < 16, "FMC ker clock too fast");
+
+        // CLE low to RE assert
+        let clr_to_nre = n_clock_periods(t_CLR);
+        let tclr = cmp::max(clr_to_nre - set - 2, 0);
+        assert!(tclr < 16, "FMC ker clock too fast");
+
+        let data_width = match config.data_width {
+            8 => 0,
+            16 => 1,
+            _ => panic!("not possible"),
+        };
+
+        // PCR
+        #[rustfmt::skip]
+        modify_reg!(fmc, self.regs.global(), PCR,
+                    TAR: tar as u32,
+                    TCLR: tclr as u32,
+                    ECCPS: 1,   // 0b1: 512 bytes
+                    ECCEN: 0,   // 0b0: ECC computation disabled
+                    PWID: data_width,
+                    PTYP: 1,    // 0b1: NAND Flash
+                    PWAITEN: 1  // 0b1: Wait feature enabled
+        );
+
+        // PMEM: Common memory space timing register
+        #[rustfmt::skip]
+        modify_reg!(fmc, self.regs.global(), PMEM,
+                    MEMHIZ: hiz as u32,
+                    MEMHOLD: hold as u32,
+                    MEMWAIT: wait as u32,
+                    MEMSET: set as u32);
+
+        // PATT: Attribute memory space timing register
+        #[rustfmt::skip]
+        modify_reg!(fmc, self.regs.global(), PATT,
+                    ATTHIZ: hiz as u32,
+                    ATTHOLD: atthold as u32,
+                    ATTWAIT: wait as u32,
+                    ATTSET: set as u32);
+
+        // Enable
+        #[rustfmt::skip]
+        modify_reg!(fmc, self.regs.global(), PCR,
+                    PBKEN: 1);
+    }
+}

--- a/src/nand.rs
+++ b/src/nand.rs
@@ -124,13 +124,16 @@ impl<IC: NandChip, FMC: FmcPeripheral> Nand<FMC, IC> {
         }
     }
 
-    /// Initialise NAND instance. Delay is used to wait
+    /// Initialise NAND instance. `delay` is used to wait 1µs after enabling the
+    /// memory controller.
     ///
-    /// Returns a [`NandDevice`] instance
+    /// Returns a [`NandDevice`](device::NandDevice) instance.
     ///
     /// # Panics
     ///
     /// * Panics if any setting in `IC::CONFIG` cannot be achieved
+    /// * Panics if the FMC Kernel Clock is too fast to achieve the timing
+    /// required by the NAND device
     pub fn init<D>(&mut self, delay: &mut D) -> device::NandDevice
     where
         D: DelayUs<u8>,

--- a/src/nand/device.rs
+++ b/src/nand/device.rs
@@ -276,7 +276,8 @@ impl NandDevice {
     /// This method starts a Page Read operation but does not include the data
     /// phase. This method is useful when DMA is used for the data phase.
     ///
-    /// For a method that completes the entire transaction see [page_read].
+    /// For a method that completes the entire transaction see
+    /// [`page_read`](Self::page_read).
     pub fn start_page_read(&mut self, address: usize, spare: bool) {
         unsafe {
             write_volatile_sync(self.common_command, 0x00);

--- a/src/nand/device.rs
+++ b/src/nand/device.rs
@@ -1,0 +1,341 @@
+//! Management of external NAND Flash through the STM32 FMC peripheral
+//!
+//! Commands and parameters are referenced to the Open NAND Flash Interface
+//! (ONFI) Specification Revision 5.1 3 May 2022
+//!
+//! Addressing supports up to 64Gb / 4GByte (8-bit data) or 128Gb / 8Gbyte (16-bit data).
+
+use core::convert::TryInto;
+use core::sync::atomic::{fence, Ordering};
+use core::{fmt, ptr, str};
+
+/// NAND Commands defined in ONFI Specification 5.1
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(unused)]
+enum Command {
+    /// 0xFF Reset: ONFI Section 5.3
+    Reset = 0xFF,
+    /// 0x90 Read ID: ONFI Section 5.6
+    ReadID = 0x90,
+    /// 0xEC Read Parameter Page: ONFI Section 5.7
+    ReadParameterPage = 0xEC,
+    /// 0xED Read Unique ID: ONFI Section 5.8
+    ReadUniqueID = 0xED,
+    /// Block Erase: ONFI Section 5.9
+    BlockErase = 0x60,
+    /// 0x70 Read Status: ONFI Section 5.10
+    ReadStatus = 0x70,
+}
+
+/// Status returned from 0x70 Read Status: ONFI Section 5.10
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Status {
+    /// Status Register indicated Pass
+    Success(u8),
+    /// Status Register indicates Fail
+    Fail(u8),
+}
+impl Status {
+    fn from_register(reg: u8) -> Self {
+        match reg & 1 {
+            1 => Self::Fail(reg),
+            _ => Self::Success(reg),
+        }
+    }
+}
+
+/// Identifier returned from 0x90 Read ID: ONFI Section 5.6
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ID {
+    manufacturer_jedec: u8,
+    device_jedec: u8,
+    internal_chip_count: usize,
+    page_size: usize,
+}
+
+/// Parameter Page returned from 0xEC Read Parameter Page: ONFI Section 5.7
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Clone, Copy, PartialEq)]
+pub struct ParameterPage {
+    signature: [u8; 4],
+    onfi_revision: u16,
+    manufacturer: [u8; 12],
+    model: [u8; 20],
+    date_code: u16,
+    data_bytes_per_page: u32,
+    spare_bytes_per_page: u16,
+    pages_per_block: u32,
+    blocks_per_lun: u32,
+    lun_count: u8,
+    ecc_bits: u8,
+}
+impl ParameterPage {
+    /// Manufacturer of the device
+    pub fn manufacturer(&self) -> &str {
+        str::from_utf8(&self.manufacturer).unwrap_or("<ERR>")
+    }
+    /// Model number of the deviceo
+    pub fn model(&self) -> &str {
+        str::from_utf8(&self.model).unwrap_or("<ERR>")
+    }
+}
+impl fmt::Debug for ParameterPage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ONFI Parameter Page")
+            .field("ONFI Revision", &self.onfi_revision)
+            .field("Manufacturer", &self.manufacturer())
+            .field("Model", &self.model())
+            .field("Date Code", &self.date_code)
+            .field("Data bytes per Page", &self.data_bytes_per_page)
+            .field("Spare bytes per Page", &self.spare_bytes_per_page)
+            .field("Pages per Block", &self.pages_per_block)
+            .field("Blocks per LUN", &self.blocks_per_lun)
+            .field("LUN Count", &self.lun_count)
+            .field("ECC Bits Correctability", &self.ecc_bits)
+            .finish()
+    }
+}
+
+/// NAND Device
+#[derive(Clone, Debug, PartialEq)]
+#[allow(missing_copy_implementations)]
+pub struct NandDevice {
+    common_command: *mut u8,
+    common_address: *mut u8,
+    attribute_command: *mut u8,
+    common_data: *mut u8,
+
+    /// Number of address bits C that are used for the column address. The
+    /// number of data bytes per page is typically 2^C
+    column_bits: Option<usize>,
+}
+
+unsafe fn write_volatile_sync<T>(dest: *mut T, src: T) {
+    ptr::write_volatile(dest, src);
+
+    // Ensure that the write is committed before continuing. In the default
+    // ARMv7-M address map the space 0x8000_0000-0x9FFF_FFFF is Normal Memory
+    // with write-though cache attribute.
+    fence(Ordering::SeqCst);
+}
+
+impl NandDevice {
+    /// Create a `NandDevice` from a bank pointer
+    ///
+    /// # Safety
+    ///
+    /// The FMC controller must have been initialized as NAND controller and
+    /// enabled for this bank, with the correct pin settings. The bank pointer
+    /// must be a singleton.
+    pub(crate) unsafe fn init(ptr: *mut u8, column_bits: usize) -> NandDevice {
+        let mut nand = NandDevice {
+            common_command: ptr.add(0x1_0000),
+            common_address: ptr.add(0x2_0000),
+            attribute_command: ptr.add(0x801_0000),
+            common_data: ptr,
+            column_bits: Some(column_bits),
+        };
+
+        // Reset Command. May be specifically required by some devices and there
+        // seems to be no disadvantage of sending it always
+        nand.reset();
+
+        nand
+    }
+    /// 0xFF Reset: ONFI Section 5.3
+    pub fn reset(&mut self) {
+        unsafe {
+            write_volatile_sync(self.common_command, 0xFF);
+        }
+    }
+    /// Generic Command
+    fn command(&mut self, cmd: Command, address: u8, buffer: &mut [u8]) {
+        unsafe {
+            write_volatile_sync(self.common_command, cmd as u8);
+            write_volatile_sync(self.common_address, address);
+            for x in buffer {
+                *x = ptr::read_volatile(self.common_data);
+            }
+        }
+    }
+    /// Generic Address
+    ///
+    /// column_bits must be set first!
+    fn address(&mut self, address: usize, spare: bool) {
+        let column_bits = self
+            .column_bits
+            .expect("Number of column bits must be configured first");
+        let column = (address & ((1 << column_bits) - 1))
+            + if spare { 1 << column_bits } else { 0 };
+        let row = address >> column_bits;
+
+        let mut addr_cycles = [0u8; 5];
+
+        // Assuming 5-cycle address
+        addr_cycles[0] = (column & 0xFF) as u8;
+        addr_cycles[1] = ((column >> 8) & 0xFF) as u8;
+        addr_cycles[2] = (row & 0xFF) as u8;
+        addr_cycles[3] = ((row >> 8) & 0xFF) as u8;
+        addr_cycles[4] = ((row >> 16) & 0xFF) as u8;
+
+        for a in addr_cycles {
+            unsafe {
+                write_volatile_sync(self.common_address, a);
+            }
+        }
+    }
+
+    /// 0x90 Read ID: ONFI Section 5.6
+    pub fn read_id(&mut self) -> ID {
+        let mut id = [0u8; 5];
+        self.command(Command::ReadID, 0, &mut id);
+
+        let internal_chip_count = match id[2] & 3 {
+            1 => 2,
+            2 => 4,
+            3 => 8,
+            _ => 1,
+        };
+        let page_size = match id[3] & 3 {
+            1 => 2048,
+            2 => 4096,
+            _ => 0,
+        };
+        ID {
+            manufacturer_jedec: id[0],
+            device_jedec: id[1],
+            internal_chip_count,
+            page_size,
+        }
+    }
+    /// 0xEC Read Parameter Page: ONFI Section 5.7
+    pub fn read_parameter_page(&mut self) -> ParameterPage {
+        let mut page = [0u8; 115];
+        self.command(Command::ReadParameterPage, 0, &mut page);
+
+        ParameterPage {
+            signature: page[0..4].try_into().unwrap(),
+            onfi_revision: u16::from_le_bytes(page[4..6].try_into().unwrap()),
+            manufacturer: page[32..44].try_into().unwrap(),
+            model: page[44..64].try_into().unwrap(),
+            date_code: u16::from_le_bytes(page[65..67].try_into().unwrap()),
+            data_bytes_per_page: u32::from_le_bytes(
+                page[80..84].try_into().unwrap(),
+            ),
+            spare_bytes_per_page: u16::from_le_bytes(
+                page[84..86].try_into().unwrap(),
+            ),
+            pages_per_block: u32::from_le_bytes(
+                page[92..96].try_into().unwrap(),
+            ),
+            blocks_per_lun: u32::from_le_bytes(
+                page[96..100].try_into().unwrap(),
+            ),
+            lun_count: page[100],
+            ecc_bits: page[112],
+        }
+    }
+    /// 0xED Read Unique ID: ONFI Section 5.8
+    pub fn read_unique_id(&mut self) -> u128 {
+        let mut unique = [0u8; 16];
+        self.command(Command::ReadUniqueID, 0, &mut unique);
+        u128::from_le_bytes(unique)
+    }
+    /// 0x60 Block Erase: ONFI Section 5.9
+    pub fn block_erase(&mut self, address: usize) -> Status {
+        unsafe {
+            write_volatile_sync(self.common_command, 0x60); // auto block erase setup
+        }
+
+        let column_bits = self
+            .column_bits
+            .expect("Number of column bits must be configured first!");
+        let row = address >> column_bits;
+        unsafe {
+            // write block address
+            write_volatile_sync(self.common_address, (row & 0xFF) as u8);
+            write_volatile_sync(self.common_address, ((row >> 8) & 0xFF) as u8);
+            write_volatile_sync(
+                self.common_address,
+                ((row >> 16) & 0xFF) as u8,
+            );
+
+            // erase command
+            write_volatile_sync(self.attribute_command, 0xD0); // t_WB
+            write_volatile_sync(self.common_command, Command::ReadStatus as u8);
+            let status_register = ptr::read_volatile(self.common_data);
+            Status::from_register(status_register)
+        }
+    }
+
+    /// Page Read: ONFI Section 5.14
+    ///
+    /// This method starts a Page Read operation but does not include the data
+    /// phase. This method is useful when DMA is used for the data phase.
+    ///
+    /// For a method that completes the entire transaction see [page_read].
+    pub fn start_page_read(&mut self, address: usize, spare: bool) {
+        unsafe {
+            write_volatile_sync(self.common_command, 0x00);
+            self.address(address, spare);
+            write_volatile_sync(self.attribute_command, 0x30); // t_WB
+        }
+    }
+    /// Page Read: ONFI Section 5.14
+    ///
+    /// Executes a Page Read operation from the specified address. Data is
+    /// copied to the slice `page`. The length of `page` determines the read
+    /// length. The read length should not exceed the number of bytes between
+    /// the specified address and the end of the page. Reading beyond the end of
+    /// the page results in indeterminate values being returned.
+    ///
+    /// If `spare` is true, then the read occours from the spare area. The
+    /// address offset from the start of the page plus the slice length should
+    /// not exceed the spare area size.
+    pub fn page_read(&mut self, address: usize, spare: bool, page: &mut [u8]) {
+        self.start_page_read(address, spare);
+        for x in page {
+            unsafe {
+                *x = ptr::read_volatile(self.common_data);
+            }
+        }
+    }
+
+    /// Page Program: ONFI Section 5.16
+    ///
+    /// Executes a page program to the specified address and waits for it to
+    /// complete. The length of `page` determines the write length. The write
+    /// length should not exceed the number of bytes between the specified
+    /// address and the end of the page. Writing beyond this length is
+    /// undefined.
+    pub fn page_program(
+        &mut self,
+        address: usize,
+        spare: bool,
+        page: &[u8],
+    ) -> Status {
+        unsafe {
+            write_volatile_sync(self.common_command, 0x80); // data input
+            self.address(address, spare);
+            for x in page {
+                write_volatile_sync(self.common_data, *x); // write page
+            }
+            write_volatile_sync(self.attribute_command, 0x10); // program command, t_WB
+            let mut status_register;
+            while {
+                write_volatile_sync(
+                    self.common_command,
+                    Command::ReadStatus as u8,
+                );
+                status_register = ptr::read_volatile(self.common_data);
+
+                status_register & 0x20 == 0 // program in progress
+            } {}
+
+            Status::from_register(status_register)
+        }
+    }
+}

--- a/src/nand/device.rs
+++ b/src/nand/device.rs
@@ -340,3 +340,53 @@ impl NandDevice {
         }
     }
 }
+
+/// Methods to allow users to implement their own commands using `unsafe`.
+///
+impl NandDevice {
+    /// Return a Raw Pointer to the common command space. This memory-mapped
+    /// address is used to write command phase of NAND device transactions.
+    ///
+    /// It is recommended to use
+    /// [`ptr::write_volatile`](https://doc.rust-lang.org/std/ptr/fn.write_volatile.html)
+    /// to write to this pointer. Depending on the memory map in use, you may
+    /// need to ensure the write is committed by using
+    /// [`core::atomic::sync::fence`](https://doc.rust-lang.org/core/sync/atomic/fn.fence.html).
+    pub fn common_command(&mut self) -> *mut u8 {
+        self.common_command
+    }
+    /// Return a Raw Pointer to the attribute command space. This memory-mapped
+    /// address is used to write command phase of NAND device transactions.
+    ///
+    /// It is recommended to use
+    /// [`ptr::write_volatile`](https://doc.rust-lang.org/std/ptr/fn.write_volatile.html)
+    /// to write to this pointer. Depending on the memory map in use, you may
+    /// need to ensure the write is committed by using
+    /// [`core::atomic::sync::fence`](https://doc.rust-lang.org/core/sync/atomic/fn.fence.html).
+    pub fn attribute_command(&mut self) -> *mut u8 {
+        self.attribute_command
+    }
+    /// Return a Raw Pointer to the common address space. This memory-mapped
+    /// address is used to write the address phase of NAND device transactions.
+    ///
+    /// It is recommended to use
+    /// [`ptr::write_volatile`](https://doc.rust-lang.org/std/ptr/fn.write_volatile.html)
+    /// to write to this pointer. Depending on the memory map in use, you may
+    /// need to ensure the write is committed by using
+    /// [`core::atomic::sync::fence`](https://doc.rust-lang.org/core/sync/atomic/fn.fence.html).
+    pub fn common_address(&mut self) -> *mut u8 {
+        self.common_address
+    }
+    /// Return a Raw Pointer to the common data space. This memory-mapped
+    /// address is used to write or read the data phase of NAND device
+    /// transactions.
+    ///
+    /// It is recommended to use
+    /// [`ptr::write_volatile`](https://doc.rust-lang.org/std/ptr/fn.write_volatile.html)
+    /// to write to this pointer. Depending on the memory map in use, you may
+    /// need to ensure the write is committed by using
+    /// [`core::atomic::sync::fence`](https://doc.rust-lang.org/core/sync/atomic/fn.fence.html).
+    pub fn common_data(&mut self) -> *mut u8 {
+        self.common_data
+    }
+}


### PR DESCRIPTION
Adds support for 8-bit parallel NAND flash. Includes basic page_read, page_program and block_erase methods.

Tested with a SkyHigh S34ML08G3 SLC NAND